### PR TITLE
Detect QtWebEngine's Chromium version from its default UA

### DIFF
--- a/src/Morph/Web/MorphWebContext.qml
+++ b/src/Morph/Web/MorphWebContext.qml
@@ -28,12 +28,12 @@ WebEngineProfile {
     property alias incognito: oxideContext.offTheRecord
     readonly property string defaultUserAgent: __ua.defaultUA
 
+    property string chromiumVersion
+
     dataPath: dataLocation
 
     cachePath: cacheLocation
     maxCacheSizeHint: cacheSizeHint
-
-    userAgent: defaultUserAgent
 
     persistentCookiesPolicy: WebEngineProfile.ForcePersistentCookies
 
@@ -70,6 +70,8 @@ WebEngineProfile {
     ]
 
     property QtObject __ua: UserAgent02 {
+        chromiumVersion: oxideContext.chromiumVersion
+
         onScreenSizeChanged: reloadOverrides()
         Component.onCompleted: reloadOverrides()
 
@@ -91,16 +93,22 @@ WebEngineProfile {
             }
             if (temp !== null) {
                 console.log("Loaded %1 UA override(s) from %2".arg(temp.overrides.length).arg(Qt.resolvedUrl(script)))
-                var chromiumVersion = "65.0.3325.151" // TODO: find out how to get this from QtWebEngine
                 var overrides = []
                 for (var o in temp.overrides) {
                     var override = temp.overrides[o]
-                    overrides.push([override[0], override[1].replace(/\$\{CHROMIUM_VERSION\}/g, chromiumVersion)])
+                    overrides.push([override[0], override[1].replace(/\$\{CHROMIUM_VERSION\}/g, oxideContext.chromiumVersion)])
                 }
                 userAgentOverrides = overrides
                 temp.destroy()
             }
         }
+    }
+
+    Component.onCompleted: {
+        // Get Chromium version from the QtWebEngine's default UA.
+        var regex = /(^| )(Chrome|Chromium)\/([0-9.]*)( |$)/;
+        chromiumVersion = userAgent.match(regex)[3];
+        userAgent = defaultUserAgent;
     }
 
     /*

--- a/src/Morph/Web/UserAgent02.qml
+++ b/src/Morph/Web/UserAgent02.qml
@@ -32,6 +32,9 @@ QtObject {
     // mobile UA string is used, screens bigger than that will get desktop content.
     property string screenSize: calcScreenSize()
 
+    // To be set from outside
+    property string chromiumVersion
+
     // %1: Ubuntu version, e.g. "14.04"
     // %2: optional token to specify further attributes of the platform, e.g. "like Android"
     // %3: optional hardware ID token
@@ -54,8 +57,6 @@ QtObject {
     // See chromium/src/content/webkit_version.h.in in oxide’s source tree.
     readonly property string _webkitVersion: "537.36"
 
-    readonly property string _chromiumVersion: "65.0.3325.151" // TODO figure out how to get this
-
     readonly property string _formFactor: screenSize === "small" ? "Mobile" : ""
 
     readonly property string _more: ""
@@ -74,7 +75,7 @@ QtObject {
         ua = ua.arg((_attributes !== "") ? " %1".arg(_attributes) : "") // %2
         ua = ua.arg((_hardwareID !== "") ? "; %1".arg(_hardwareID) : "") // %3
         ua = ua.arg(_webkitVersion) // %4
-        ua = ua.arg(_chromiumVersion) // %5
+        ua = ua.arg(chromiumVersion) // %5
         ua = ua.arg((_formFactor !== "") ? "%1 ".arg(_formFactor) : "") // %6
         ua = ua.arg(_webkitVersion) // %7
         ua = ua.arg((_more !== "") ? " %1".arg(_more) : "") // %8


### PR DESCRIPTION
As long as we don't overwrite it, we can get the default user agent from
WebEngineContext and parse Chrome/Chromium version out of it. Do that on
Component.onCompleted before setting our user-agent.